### PR TITLE
use Build::SearchDep for proper dynamic prereqs

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -38,16 +38,9 @@ share {
     requires 'Alien::m4'       => '0.11';
 
     if ($^O eq 'linux') {
-        requires 'Alien::libudev' => '0.1';
-        eval "use Alien::libudev"; die $@ if $@;
-        $cppflags  = Alien::libudev->cflags // '';
-        $ldflags   = Alien::libudev->libs // '';
-
-        meta->after_hook(gather_share => sub {
-            my($build) = @_;
-            $build->runtime_prop->{$_} .= ' ' . $ldflags for qw( libs libs_static );
-            $build->runtime_prop->{cflags} .= ' ' . $cppflags;
-        });
+        plugin 'Build::SearchDep' => (
+          aliens => { 'Alien::libudev' => '0.1' },
+        );
     }
 
     plugin Download => (
@@ -69,8 +62,6 @@ share {
     plugin 'Build::Autoconf' => ();
 
     $ENV{NOCONFIGURE}  = 1;
-    $ENV{CPPFLAGS}    .= " $cppflags";
-    $ENV{LDFLAGS}     .= " $ldflags";
 
     build [
         './autogen.sh',

--- a/dist.ini
+++ b/dist.ini
@@ -5,9 +5,6 @@ copyright_holder = Ahmad Fatoum
 copyright_year   = 2017
 
 [AutoPrereqs]
-[OSPrereqs / linux]
-Alien::libudev = 0.14
-
 [@Starter]
 
 [AlienBuild]


### PR DESCRIPTION
I think this should fix the prereqs issues with this distro.  This sets CFLAGS instead of CPPFLAGS, and I am on macOS the moment, so this needs to be tested on Linux to be sure.  If we need to tweak the  `Build::SearchDep` plugin to use `CPPFLAGS` instead we can d othat.