### PR TITLE
README is no longer a symlink

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -53,12 +53,6 @@ share {
 
     plugin Extract => 'zip';
 
-    patch sub {
-        # README is a symlink and would make autotools fail on filesystems not supporting them
-        unlink 'README';
-        copy qw(README.md README);
-    };
-
     plugin 'Build::Autoconf' => ();
 
     $ENV{NOCONFIGURE}  = 1;

--- a/alienfile
+++ b/alienfile
@@ -1,7 +1,6 @@
 use alienfile;
 use Config;
 use Carp;
-use File::Copy qw(copy);
 
 sub isAtLeastFreeBSDv8 {
     # FreeBSD 8+ ships with a native libusb-1.0 compatible library


### PR DESCRIPTION
Hello,

Seems like recent versions of libusb does not require this patch (the patch then makes an error on my local computer).

Regards.

Thibault